### PR TITLE
Fixed Lost Seers Lenses Percent

### DIFF
--- a/ItemStats/src/ItemStatDefinitions.cs
+++ b/ItemStats/src/ItemStatDefinitions.cs
@@ -1298,7 +1298,7 @@ namespace ItemStats
 				Stats = new List<ItemStat>
 				{
 					new ItemStat(
-						(itemCount, ctx) => 0.05f * itemCount,
+						(itemCount, ctx) => 0.005f * itemCount,
 						(value, ctx) => $"Instakill Chance: {value.FormatPercentage()}"
 					),
 				},


### PR DESCRIPTION
`0.05f` is 5%, but the item is actually 0.5% which is `0.005f`. If I'm understanding it right anyway. It says 5% in game at the moment.

![image](https://user-images.githubusercontent.com/25551312/159009964-ea7312e0-eb30-44c1-8f71-f4d9ec7162cd.png)
